### PR TITLE
make the include of tabler more choosable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add Tabler and optionally Tabler Plugins to your `application.js`:
 Tabler already includes jQuery and Bootstrap javascript.  
 Tabler plugins includes the javascripts found [here][tabler-plugins].
 
-You can choose to include tabler's component when you already includes jQuery in application.js:
+If you already include jQuery in your project, you can include tabler's js on a per-file basis to avoid conflicts:
 
 ```js
 // = require tabler/tabler

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Add Tabler and optionally Tabler Plugins to your `application.js`:
 Tabler already includes jQuery and Bootstrap javascript.  
 Tabler plugins includes the javascripts found [here][tabler-plugins].
 
+You can choose to include tabler's component when you already includes jQuery in application.js:
+
+```js
+// = require tabler/tabler
+// = require tabler/vendors/bootstrap.bundle.min
+// = require tabler/vendors/circle-progress.min
+// = require tabler/vendors/jquery.sparkline.min
+// = require tabler/core
+```
+
 You can also choose to include plugin js on a per-plugin basis, for example:
 
 ```js


### PR DESCRIPTION
When I add [smart_listing](https://github.com/Sology/smart_listing) gem to my project, I found that there is a bug in smart_listing:
```
Uncaught TypeError: Cannot set property 'href' of undefined
    at smart_listing.self-c2127587124142c4ee0bd23f7389610c0eb0f8d979b5b110a24930a63c7be7ee.js?body=1:14
    at smart_listing.self-c2127587124142c4ee0bd23f7389610c0eb0f8d979b5b110a24930a63c7be7ee.js?body=1:652
```

My application.js is 
```
//= require jquery
//= require jquery_ujs
//= require turbolinks
//= require_tree .
//= require tabler
//= require tabler.plugins
//= require smart_listing
```

I found that the two requirement of jQuery is the problem. 

When I remove the jQuery, it works:
```
//= require jquery
//= require jquery_ujs
//= require turbolinks
//= require_tree .
//= require tabler/tabler
//= require tabler/vendors/bootstrap.bundle.min
//= require tabler/vendors/circle-progress.min
//= require tabler/vendors/jquery.sparkline.min
//= require tabler/core
//= require tabler.plugins
//= require smart_listing
```

Would you accept the pull request to make the include of tabler more choosable?
