### PR TITLE
Remove explicit sass usage and add bootstrap as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,9 @@
 # Changelog
 
-The changelog is tracked here but also in [the Releases section of the GitHub project](https://github.com/twbs/bootstrap-rubygem/releases).
-The changelog only includes changes specific to the RubyGem.
+### Unreleased
 
-The Bootstrap framework changes can be found in [the Releases section of twbs/bootstrap](https://github.com/twbs/bootstrap/releases).
-Release announcement posts on [the official Bootstrap blog](http://blog.getbootstrap.com) contain summaries of the most noteworthy changes made in each release of Bootstrap.
+* add `bootstrap ~> 4.3.1` as an explicit dependency which already uses `sassc` instead of the EOL'd `sass` (#13)
 
-# 4.0.0
+### 0.1.4
 
-No gem-specific changes.
-
-# 4.0.0.beta3
-
-No gem-specific changes.
-
-# 4.0.0.beta2.1
-
-Fixes an extraneous `sourceMappingURL` in `bootstrap.js`.
-[#124](https://github.com/twbs/bootstrap-rubygem/issues/124)
-
-# 4.0.0.beta2
-
-Compass is no longer supported. Minimum required Sass version is now v3.5.2.
-[#122](https://github.com/twbs/bootstrap-rubygem/pull/122)
-
-# 4.0.0.alpha3.1
-
-This release corresponds to the upstream Bootstrap 4 Alpha 3.
+Images are no longer included by default. Instead, you can include all the image sets or the specific image sets you want (either browser, flag, and/or payments).  Read below for more info on how to do this.

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'bootstrap'
+
 group :development do
   gem 'popper_js', '>= 1.12.3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'bootstrap'
-
 group :development do
   gem 'popper_js', '>= 1.12.3'
 end

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ https://github.com/tabler/tabler/tree/master/dist/assets/plugins
 [autoprefixer]: https://github.com/ai/autoprefixer
 [popper.js]: https://popper.js.org
 
-## Contributing
+## Development
 
 To set up the project and run the tests you must ensure you have the necessary browser driver installed: `brew cask install chromedriver`
 

--- a/README.md
+++ b/README.md
@@ -144,3 +144,15 @@ In the application Sass file, replace `@import 'tabler'` with:
 https://github.com/tabler/tabler/tree/master/dist/assets/plugins
 [autoprefixer]: https://github.com/ai/autoprefixer
 [popper.js]: https://popper.js.org
+
+## Contributing
+
+To set up the project and run the tests you must ensure you have the necessary browser driver installed: `brew cask install chromedriver`
+
+```
+$ mkdir tmp/
+$ bundle install
+$ rake
+```
+
+Run tests on all supported Rails versions: `rake test_all_gemfiles`

--- a/README.md
+++ b/README.md
@@ -15,16 +15,10 @@ Please see the appropriate guide for your environment of choice:
 
 ------------------------
 
-**v0.1.4 BREAKING CHANGE:**
-
-Images are no longer included by default. Instead, you can include all the image sets or the specific image sets you want (either browser, flag, and/or payments).  Read below for more info on how to do this.
-
-------------
-
 Add `bootstrap` and `tabler-rubygem` to your Gemfile:
 
 ```ruby
-gem 'bootstrap', '~> 4.1.1'
+gem 'bootstrap', '~> 4.3.1'
 gem 'tabler-rubygem'
 ```
 

--- a/lib/tabler/rubygem.rb
+++ b/lib/tabler/rubygem.rb
@@ -13,8 +13,6 @@ module Tabler
         elsif sprockets?
           register_sprockets
         end
-
-        configure_sass
       end
 
       # Paths
@@ -48,12 +46,6 @@ module Tabler
       end
 
       private
-
-      def configure_sass
-        require 'sass'
-
-        ::Sass.load_paths << stylesheets_path
-      end
 
       def register_rails_engine
         require 'tabler/rubygem/engine'

--- a/tabler.gemspec
+++ b/tabler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'term-ansicolor'
   # Integration testing
   s.add_development_dependency 'capybara', '>= 2.6.0'
-  s.add_development_dependency 'poltergeist'
+  s.add_development_dependency 'selenium-webdriver'
   # Dummy Rails app dependencies
   s.add_development_dependency 'actionpack', '>= 4.1.5'
   s.add_development_dependency 'activesupport', '>= 4.1.5'

--- a/tabler.gemspec
+++ b/tabler.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
 
   s.add_runtime_dependency 'autoprefixer-rails', '>= 6.0.3'
+  s.add_runtime_dependency 'bootstrap', '~> 4.3.1'
 
   # Testing dependencies
   s.add_development_dependency 'minitest', '~> 5.8.0'

--- a/test/gemfiles/rails_4_2.gemfile
+++ b/test/gemfiles/rails_4_2.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 4.2.7'
 gem 'activesupport', '~> 4.2.7'
+gem 'bootstrap'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_4_2.gemfile
+++ b/test/gemfiles/rails_4_2.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 4.2.7'
 gem 'activesupport', '~> 4.2.7'
-gem 'bootstrap'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_5_0.gemfile
+++ b/test/gemfiles/rails_5_0.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'
-gem 'autoprefixer-rails', '>= 6.3.6.1'
+gem 'bootstrap'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_5_0.gemfile
+++ b/test/gemfiles/rails_5_0.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'
-gem 'bootstrap'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_5_1.gemfile
+++ b/test/gemfiles/rails_5_1.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.0'
-gem 'bootstrap'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_5_1.gemfile
+++ b/test/gemfiles/rails_5_1.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.0'
-gem 'autoprefixer-rails', '>= 7.1.1'
+gem 'bootstrap'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_5_2.gemfile
+++ b/test/gemfiles/rails_5_2.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 5.2.0'
 gem 'activesupport', '~> 5.2.0'
-gem 'bootstrap'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_5_2.gemfile
+++ b/test/gemfiles/rails_5_2.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'actionpack', '~> 5.2.0'
+gem 'activesupport', '~> 5.2.0'
+gem 'bootstrap'
+
+gemspec path: '../../'

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -3,13 +3,21 @@ require 'test_helper_rails'
 class RailsTest < ActionDispatch::IntegrationTest
   include ::DummyRailsIntegration
 
-  def test_visit_root
+  def test_visit_root_render
     visit root_path
-    # ^ will raise on JS errors
 
-    assert_equal 200, page.status_code
+    page.has_content?('Success')
 
     screenshot!
+  end
+
+  def test_root_has_no_javascript_errors
+    visit root_path
+
+    browser_logs = page.driver.browser.manage.logs.get(:browser).to_a
+    browser_logs.each do |error|
+      refute error.level == 'SEVERE', error.message
+    end
   end
 
   def test_autoprefixer

--- a/test/support/dummy_rails_integration.rb
+++ b/test/support/dummy_rails_integration.rb
@@ -17,7 +17,7 @@ module DummyRailsIntegration
 
   def screenshot!
     path = "tmp/#{name}.png"
-    page.driver.render(File.join(GEM_PATH, path), full: true)
+    page.driver.browser.save_screenshot(File.join(GEM_PATH, path))
     STDERR.puts "Screenshot saved to #{path}"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,24 +12,10 @@ end
 
 GEM_PATH = File.expand_path('../', File.dirname(__FILE__))
 
-#= Capybara + Poltergeist
-require 'capybara/poltergeist'
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-      app,
-      # inspector:   '/Applications/Chromium.app/Contents/MacOS/Chromium', # open in inspector: page.driver.debug
-      window_size: [1280, 1024],
-      timeout:     90,
-      js_errors:   true
-  )
-end
-
 Capybara.configure do |config|
   config.app_host              = 'http://localhost:7000'
-  config.default_driver        = :poltergeist
-  config.javascript_driver     = :poltergeist
+  config.default_driver        = :selenium_chrome_headless
+  config.server                = :webrick
   config.server_port           = 7000
   config.default_max_wait_time = 10
 end
-


### PR DESCRIPTION
Builds on #14 (hence the commits in the diff)
Fixes #13 

I'm still unsure about adding `bootstrap` as a dependency because this way we might lock the version and users cannot upgrade it independently if 4.4.x comes out. :| But this seems more correct to me.
As a middle ground, we could be more liberal and set the version as `~> 4.3`? 🤔 
What do you think?